### PR TITLE
enhance Formable API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val diodeVersion = "1.1.14"
 lazy val token = sys.env.getOrElse("GITHUB_TOKEN", "No Token")
 
 val publishSettings = Seq(
-  version := "0.2.0-SNAPSHOT",
+  version := "0.3.0-SNAPSHOT",
   versionScheme := Some(sbt.VersionScheme.SemVerSpec),
   organization := "rocks.earlyeffect",
   organizationName := "earlyeffect",
@@ -109,7 +109,7 @@ lazy val formable = project
   .settings(
     baseSettings,
     publishSettings,
-    name := "anode-diode-support",
+    name := "anode-formable",
     libraryDependencies += "com.propensive" %%% "magnolia" % "0.17.0" ,
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     Compile / fastOptJS / webpackEmitSourceMaps := true,

--- a/demo-app/src/main/scala/todo/App.scala
+++ b/demo-app/src/main/scala/todo/App.scala
@@ -1,8 +1,8 @@
 package todo
 
-import diode.ModelR
 import anode.dsl.css.CssClass
 import anode.{ClassSelector, E, S, VNode, fragment, when}
+import diode.ModelR
 import todo.model.{Root, TodoList}
 
 object App extends TodoComponent[Unit, TodoList] with ClassSelector {
@@ -59,6 +59,8 @@ object App extends TodoComponent[Unit, TodoList] with ClassSelector {
   }
 
   override def modelReader(p: Unit): ModelR[Root, TodoList] = zoom(_.todoList)
+  import anode.Formable
+  import Formable.defaultImplicits._
 
   override def render(props: Unit, l: TodoList): VNode =
     E.body(

--- a/formable/src/main/scala/anode/Formable.scala
+++ b/formable/src/main/scala/anode/Formable.scala
@@ -5,6 +5,7 @@ import magnolia.{CaseClass, Magnolia}
 import org.scalajs.dom
 
 import scala.language.experimental.macros
+import scala.language.implicitConversions
 
 sealed trait Formable[A] { self =>
   def apply(props: Props[A, _]): Args
@@ -16,46 +17,53 @@ sealed trait Formable[A] { self =>
 }
 
 object Formable {
-  case class Props[Field, Product](label: String, field: Field, update: Field => Product)
-
-  object Props {
-
-    def apply[Product, Result](product: Product, effect: Product => Result) =
-      new Props[Product, Product](
-        label = "form",
-        product,
-        x => {
-          effect(x)
-          x
-        },
-      )
-  }
   type Typeclass[A] = Formable[A]
 
-  implicit class FormableProduct[A](a: A)(implicit f: Formable[A]) {
-    def form[T](effect: A => T): anode.VNode = f.form(Props[A, T](a, effect))
-    def apply[T](effect: A => T): anode.Args = f(Props[A,T](a,effect))
+  case class Props[Field, Product] private[anode] (label: String, field: Field, update: Field => Product)
+
+  def apply[Field, Product](label: String, field: Field)(update: Field => Product): Props[Field, Product] =
+    Props(label, field, update)
+
+  def apply[Product, Result](product: Product)(effect: Product => Result): Props[Product, Product] =
+    Props[Product, Product](
+      label = "form",
+      product,
+      x => {
+        effect(x)
+        x
+      },
+    )
+
+  implicit class FormableProduct[Product](product: Product)(implicit f: Formable[Product]) {
+    def form[A](effect: Product => A): anode.VNode = f.form(Formable[Product, A](product)(effect))
+    def apply[A](effect: Product => A): anode.Args = f(Formable[Product, A](product)(effect))
   }
 
   def apply[A](f: Props[A, _] => Args): Formable[A] =
     new Formable[A] { override def apply(props: Props[A, _]): Args = f(props) }
 
-  def combine[A](caseClass: CaseClass[Typeclass, A]): Formable[A] =
+  def combine[Product](caseClass: CaseClass[Typeclass, Product]): Formable[Product] =
     Formable { props =>
-      args(caseClass.parameters.map { p =>
-        val update: p.PType => A = (x: p.PType) => {
-          val product = caseClass.construct { cp =>
-            if (cp == p) x
-            else cp.dereference(props.field)
+      args(caseClass.parameters.map { productParam =>
+        type ParamType = productParam.PType
+        val update: ParamType => Product = (x: ParamType) => {
+          val product = caseClass.construct { constructorParam =>
+            if (constructorParam == productParam) x
+            else constructorParam.dereference(props.field)
           }
           props.update(product)
           product
         }
-        p.typeclass(Props(p.label, p.dereference(props.field), update))
+        productParam.typeclass(apply(productParam.label, productParam.dereference(props.field))(update))
       })
     }
   implicit def formable[A]: Formable[A] = macro Magnolia.gen[A]
+
+  implicit def summonArgsFromProps[Field](props: Props[Field, _])(implicit formable: Formable[Field]): Args =
+    formable(props)
+
   object defaultImplicits {
+
     implicit val string: Formable[String] = Formable { p =>
       args(
         E.div(


### PR DESCRIPTION
Makes it possible create args from an implicit Formable like this:

```Scala
      Formable(label = "foo", field = "bar")(updatedField => ())
```

Also I used a second param group for the effect function - so that we get better type inference for the update/effect function.